### PR TITLE
Identify 2020 standard sites

### DIFF
--- a/docs/documentation_tab.R
+++ b/docs/documentation_tab.R
@@ -6,10 +6,13 @@ documentation_panel <- function(){
         provided in the corresponding site details record. If there are two or more records for any given site then
         the install date provided in the first record is used. Installation dates before 2015-10-01 are asigned to
         the AS4777.3:2005 standard, dates on or after 2015-10-01 and before 2016-11-01 are asigned to the Transition 
-        standard and dates on or after the 2016-11-01 are asigned to the AS4777.2:2015 standard. Where only a 
-        month and year are given for the installation date then an installation day of the 28th of the month is 
-        assumed. Where no date is given or the date cannot be converted to a datetime object then a date of 
-        2015-11-28 is assumed, placing the date in the Transition standard.'),
+        standard. Dates on or after the 2016-11-01 and before 2020-12-01 are asigned to the AS4777.2:2015 standard, 
+        except for South Australia where dates on or after 2020-10-01 are assigned to AS4777.2:2015 VDRT. Dates on or 
+        after 2020-12-01 and before 2022-01-01 are assigned to AS4777.2:2020. This means that only a small fraction of 
+        dates will be assigned to AS4777.2:2015 VDRT (i.e. install dates for South Australian systems during 2020-10 and 
+        2020-11). Dates Where only a month and year are given for the installation date then an installation day of the 
+        28th of the month is assumed. Where no date is given or the date cannot be converted to a datetime object then 
+        a date of 2015-11-28 is assumed, placing the date in the Transition standard.'),
     h4('Response category definition'),
     div('Circuits can be assigned one of 8 response types, 4 of which represent actual response types and 4 which
         provided a reason a circuit could not be categorised. The actual response categories are:'),

--- a/process_input_data/process_input_data_functions.R
+++ b/process_input_data/process_input_data_functions.R
@@ -200,8 +200,8 @@ site_categorisation <- function(combined_data){
     mutate(Standard_Version=ifelse(pv_installation_year_month >= "2016-11-01" & 
                                    pv_installation_year_month < "2020-10-01" & s_state == 'SA',
                                    "AS4777.2:2015", Standard_Version)) %>%
-    # Systems installed in SA during October 2020
-    # New assumption: systems installed during December 2020 are "transition 2". This means the VDRT group will be small
+    # Assumes systems installed in SA during October 2020 are 2015 VDRT" and systems installed during December 2020 
+    # are "transition 2". This means the VDRT group will be small (only 2mon).
     mutate(Standard_Version=ifelse(pv_installation_year_month >= "2020-10-01" & s_state == 'SA' &
                                      pv_installation_year_month < "2020-12-01",
                                    "AS4777.2:2015 VDRT", Standard_Version)) %>%

--- a/process_input_data/tests/test_process_input_data_functions.R
+++ b/process_input_data/tests/test_process_input_data_functions.R
@@ -159,23 +159,26 @@ test_that("Test the power calculations",{
 
 test_that("Test the standard categorisation function",{
   # Test input data
-  site_id <- c(101, 50, 10002, 89, 567, 111, 1)
-  s_state <- c("NSW", "NSW", "SA", "VIC", "QLD", "SA", "TAS")
-  sum_dc <- c(60, 60, 10, 60, 60, 10, 11)
-  first_ac <- c(60, 60, 10, 60, 60, 10, 11)
-  pv_installation_year_month <- c("", NA, "2015-01", "2015-10-09", "2015-11", "2016-10-09", "2017-10")
+  site_id <- c(101, 50, 10002, 89, 567, 111, 1, 88, 4, 155, 40)
+  s_state <- c("NSW", "NSW", "SA", "VIC", "QLD", "SA", "TAS", "SA", "SA", "QLD", "NSW")
+  sum_dc <- c(60, 60, 10, 60, 60, 10, 11, 12, 20, 5, 6)
+  first_ac <- c(60, 60, 10, 60, 60, 10, 11, 12, 20, 5, 6)
+  pv_installation_year_month <- c("", NA, "2015-01", "2015-10-09", "2015-11", "2016-10-09", "2017-10", "2020-10", 
+                                  "2020-12-08", "2021-02", "2022-01-14")
   test_site_details <- data.frame(site_id, s_state, sum_dc, first_ac,
                                   pv_installation_year_month,
                                   stringsAsFactors = FALSE)
   # Test output data
-  site_id <- c(101, 50, 10002, 89, 567, 111, 1)
-  s_state <- c("NSW", "NSW", "SA", "VIC", "QLD", "SA", "TAS")
-  sum_dc <- c(60, 60, 10, 60, 60, 10, 11)
-  first_ac <- c(60, 60, 10, 60, 60, 10, 11)
+  site_id <- c(101, 50, 10002, 89, 567, 111, 1, 88, 4, 155, 40)
+  s_state <- c("NSW", "NSW", "SA", "VIC", "QLD", "SA", "TAS", "SA", "SA", "QLD", "NSW")
+  sum_dc <- c(60, 60, 10, 60, 60, 10, 11, 12, 20, 5, 6)
+  first_ac <- c(60, 60, 10, 60, 60, 10, 11, 12, 20, 5, 6)
   pv_installation_year_month <- c(ymd("2015-11-28"), ymd("2015-11-28"), ymd("2015-01-28"), ymd("2015-10-09"),
-                                  ymd("2015-11-28"), ymd("2016-10-09"), ymd("2017-10-28"))
-  Standard_Version <- c("Transition", "Transition", "AS4777.3:2005", "Transition", "Transition", "Transition", 
-                        "AS4777.2:2015")
+                                  ymd("2015-11-28"), ymd("2016-10-09"), ymd("2017-10-28"), ymd("2020-10-28"), 
+                                  ymd("2020-12-08"), ymd("2021-02-28"), ymd("2022-01-14"))
+  Standard_Version <- c("Transition", "Transition", "AS4777.3:2005", "Transition", "Transition", 
+                        "Transition", "AS4777.2:2015", "AS4777.2:2015 VDRT", "Transition 2020-21", "Transition 2020-21", 
+                        "AS4777.2:2020")
   expected_answer <- data.frame(site_id, s_state, sum_dc, first_ac, pv_installation_year_month, Standard_Version,
                                 stringsAsFactors = FALSE)
   # Call processing function

--- a/shiny.R
+++ b/shiny.R
@@ -598,8 +598,10 @@ server <- function(input,output,session){
       output$StdVersion <- renderUI({
         checkboxGroupButtons(inputId="StdVersion", 
                               label=strong("AS47777 Version:"), choices=list("AS4777.3:2005", "Transition", 
-                                                                            "AS4777.2:2015", "AS4777.2:2015 VDRT"),
-                              selected=list("AS4777.3:2005", "Transition", "AS4777.2:2015", "AS4777.2:2015 VDRT"),
+                                                                            "AS4777.2:2015", "AS4777.2:2015 VDRT", 
+                                                                            "Transition 2020-21", "AS4777.2:2020"),
+                              selected=list("AS4777.3:2005", "Transition", "AS4777.2:2015", "AS4777.2:2015 VDRT", 
+                                            "Transition 2020-21", "AS4777.2:2020"),
                               justified=TRUE, status="primary", individual=TRUE,
                               checkIcon=list(yes=icon("ok", lib="glyphicon"), no=icon("remove", lib="glyphicon")),
                               direction = "vertical")


### PR DESCRIPTION
Purpose is to be able to identify sites installed under (1) the Transition period from 18 Dec 2020 - 18 Dec 2021 and (2) the updated AS4777.2:2020 

Checked the db build process and couldn't find anything that needed changing to accommodate the update. 

Created a db for 2020-01-31 event using 'dummy' install month-year of 2022-02 for all sites. Was able to create the db, run the GUI and output circuit summary. 