### PR TITLE
Hotfix confidence interval unit test

### DIFF
--- a/upscale_disconnections/tests/test_summarise_disconnections.R
+++ b/upscale_disconnections/tests/test_summarise_disconnections.R
@@ -107,12 +107,12 @@ testthat::test_that("calc_confidence_intervals_for_disconnections",{
 testthat::test_that("calc_upscale_kw_loss",{
   
   input <- "Standard_Version, manufacturer, disconnections, sample_size, cer_capacity, proportion, lower_bound, upper_bound
-                           y,        Other,              5,           6,           21,  0.8333333,   0.3583333,    0.996333  
-                           z,            x,              0,          30,           12,          0,         0.0,   0.1160000"
+                           y,        Other,              5,           6,           21,  0.8333333,   0.3587654,   0.9957893  
+                           z,            x,              0,          30,           12,          0,         0.0,   0.1157033"
   
   expected_output <- "Standard_Version, manufacturer, disconnections, sample_size, cer_capacity, proportion, lower_bound, upper_bound, predicted_kw_loss, lower_bound_kw_loss, upper_bound_kw_loss
-                                     y,        Other,              5,           6,           21,  0.8333333,   0.3583333,   0.9963333,              17.5,            7.524999,              20.923
-                                     z,            x,              0,          30,           12,          0,         0.0,   0.1160000,               0.0,                 0.0,               1.392"            
+                                     y,        Other,              5,           6,           21,  0.8333333,   0.3587654,   0.9957893,              17.5,           7.5340734,          20.9115753
+                                     z,            x,              0,          30,           12,          0,         0.0,   0.1157033,               0.0,                 0.0,           1.3884396"            
   
   input <- load_test_file(input)
   expected_output <- load_test_file(expected_output)

--- a/upscale_disconnections/tests/test_summarise_disconnections.R
+++ b/upscale_disconnections/tests/test_summarise_disconnections.R
@@ -91,8 +91,12 @@ testthat::test_that("calc_confidence_intervals_for_disconnections",{
                            z,            x,              0,          30,           12,          0"
   
   expected_output <- "Standard_Version, manufacturer, disconnections, sample_size, cer_capacity, proportion, lower_bound, upper_bound
-                                     y,        Other,              5,           6,           21,  0.8333333,   0.3583333,   0.9963333
-                                     z,            x,              0,          30,           12,          0,         0.0,   0.1160000"
+                                     y,        Other,              5,           6,           21,  0.8333333,   0.3587654,   0.9957893
+                                     z,            x,              0,          30,           12,          0,         0.0,   0.1157033"
+  
+  # Clopper-Pearson confidence interval for n = 6, 5 succcesses is [0.3587654, 0.9957893]
+  # Clopper-Pearson confidence interval for  n = 30, 0 successes is [0, 0.1157033]
+  # Source: https://epitools.ausvet.com.au/ciproportion
   
   input <- load_test_file(input)
   expected_output <- load_test_file(expected_output)


### PR DESCRIPTION
A lower bound and an upper bound in unit tests for calc_confidence_intervals_for_disconnections were only correct to 3 decimal places while the testthat tolerance was four decimal places. These tests passed under the old confidence interval function as its default tolerance was three decimal places.

The tests have been updated with more accurate lower & upper bounds (7 decimal places) which pass under the new bisection method function with default tolerance settings.

Apologies - I should have spotted this when merging in the bisection method function!