### PR TITLE
Hotfix analysis failed if not in a git repo

### DIFF
--- a/run_analysis/run_analysis.R
+++ b/run_analysis/run_analysis.R
@@ -462,7 +462,11 @@ run_analysis <- function(data, settings) {
           circ_sum_cols <- append(circ_sum_cols, c("Islanded", "island_assessment", "islanding_alert"), 26)
         }
         data$circuit_summary <- data$circuit_summary[, circ_sum_cols]
-        data$circuit_summary$tool_hash <-git2r::revparse_single(revision="HEAD")$sha
+        if(is.null(git2r::discover_repository(path = ".", ceiling = NULL))){
+          data$circuit_summary$tool_hash <- Sys.Date()
+        } else {
+          data$circuit_summary$tool_hash <-git2r::revparse_single(revision="HEAD")$sha
+        }
 
         # Combine data sets that have the same grouping so they can be saved in a single file
         if (no_grouping){


### PR DESCRIPTION
Check if the tool directory is in a git repo before getting the commit stamp. Use the current date if it isn't a repo.